### PR TITLE
fix: corregir evaluación de IS_PRODUCTION en modelos Dynamoose

### DIFF
--- a/.github/workflows/only-qa-to-main.yml
+++ b/.github/workflows/only-qa-to-main.yml
@@ -1,19 +1,19 @@
- name: Only allow qa -> main
+name: Only allow qa -> main
 
- on:
-   pull_request:
-     branches: [ "main" ]
+on:
+  pull_request:
+    branches: [ "main" ]
 
- jobs:
-   guard:
-     runs-on: ubuntu-latest
-     steps:
-       - name: Block PRs not coming from qa
-         run: |
-           echo "Base: ${{ github.event.pull_request.base.ref }}"
-           echo "Head: ${{ github.event.pull_request.head.ref }}"
-           if [ "${{ github.event.pull_request.head.ref }}" != "qa" ]; then
-             echo "Error: Only PRs from 'qa' are allowed to merge into 'main'."
-             exit 1
-           fi
-           echo "Success: PR source branch is qa. Allowed."
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PRs not coming from qa
+        run: |
+          echo "Base: ${{ github.event.pull_request.base.ref }}"
+          echo "Head: ${{ github.event.pull_request.head.ref }}"
+          if [ "${{ github.event.pull_request.head.ref }}" != "qa" ]; then
+            echo "Error: Only PRs from 'qa' are allowed to merge into 'main'."
+            exit 1
+          fi
+          echo "Success: PR source branch is qa. Allowed."

--- a/src/models/actor.js
+++ b/src/models/actor.js
@@ -21,7 +21,7 @@ const actorSchema = new dynamoose.Schema({
   },
 });
 
-const isProd = process.env.IS_PRODUCTION || true;
+const isProd = process.env.IS_PRODUCTION === "true";
 
 const Actor = dynamoose.model("Actors", actorSchema, {
   create: !isProd,

--- a/src/models/article.js
+++ b/src/models/article.js
@@ -57,7 +57,7 @@ const articleSchema = new dynamoose.Schema({
   },
 })
 
-const isProd = process.env.IS_PRODUCTION || true;
+const isProd = process.env.IS_PRODUCTION === "true";
 
 const Article = dynamoose.model('Articles', articleSchema, {
   create: !isProd,

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -19,7 +19,7 @@ const locationSchema = new dynamoose.Schema({
   }
 });
 
-const isProd = process.env.IS_PRODUCTION || true;
+const isProd = process.env.IS_PRODUCTION === "true";
 
 const Location = dynamoose.model("Locations", locationSchema, {
   create: !isProd,

--- a/src/models/sourceUrl.js
+++ b/src/models/sourceUrl.js
@@ -34,7 +34,7 @@ const sourceUrlSchema = new dynamoose.Schema(
   }
 );
 
-const isProd = process.env.IS_PRODUCTION || true;
+const isProd = process.env.IS_PRODUCTION === "true";
 
 const SourceUrl = dynamoose.model("SourceUrls", sourceUrlSchema, {
   create: !isProd,

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -13,7 +13,7 @@ const tagSchema = new dynamoose.Schema({
   },
 });
 
-const isProd = process.env.IS_PRODUCTION || true;
+const isProd = process.env.IS_PRODUCTION === "true";
 
 const Tag = dynamoose.model("Tags", tagSchema, {
   create: !isProd,


### PR DESCRIPTION
##¿Qué cambia?
Se corrige el bug donde `IS_PRODUCTION` siempre evaluaba como `true` 
independientemente del valor real de la variable de entorno.

##¿Por qué?
El operador `|| true` hace que el resultado sea siempre truthy.
Cualquier string no vacío también es truthy, incluyendo `'false'`.

##Hallazgo relacionado
HR-01 — Auditoría Técnica de Base de Datos

##Archivos modificados
- src/models/article.js
- src/models/tag.js
- src/models/location.js
- src/models/actor.js
- src/models/sourceUrl.js

 ##Cómo probar
1. Setear IS_PRODUCTION=false en el archivo .env
2. Levantar el servidor local
3. Verificar que isProd evalúa como false en consola
4. Repetir con IS_PRODUCTION=true y verificar que evalúa como true