### PR TITLE
feat: implementar protección de integridad referencial

### DIFF
--- a/src/controllers/actorController.js
+++ b/src/controllers/actorController.js
@@ -1,6 +1,6 @@
 const Actor = require("../models/actor.js");
-
 const { isValidName } = require("../utils/validators");
+const referenceChecker = require('../utils/referenceChecker.js');
 
 const isValidTag = (tagId) => typeof tagId === "string";
 const isValidArticleIds = (ids) =>
@@ -105,10 +105,29 @@ const update = async (req, res) => {
 const remove = async (req, res) => {
   try {
     const { id } = req.params;
+    // If force is true, we bypass the referential integrity check.
+    // WARNING: Force deletion will leave orphaned references in Article records.
+    const force = req.query?.force === 'true';
 
     const existing = await Actor.get({ id });
     if (!existing) {
       return res.status(404).json({ error: `Actor with ID ${id} not found.` });
+    }
+
+    let references = 0;
+    if (!force) {
+      references = await referenceChecker.countReferences('actorsMentioned', id);
+      if (references > 0) {
+        return res.status(409).json({
+          error: `Cannot delete actor because it is referenced by ${references} articles.`,
+          references: references
+        });
+      }
+    } else {
+      references = await referenceChecker.countReferences('actorsMentioned', id);
+      if (references > 0) {
+        console.warn(`[AUDIT] Actor with ID "${id}" ("${existing.name}") was FORCE deleted. This left ${references} orphaned references in Articles.`);
+      }
     }
 
     await Actor.delete({ id });

--- a/src/controllers/locationController.js
+++ b/src/controllers/locationController.js
@@ -1,5 +1,6 @@
 const Location = require('../models/location.js');
 const { isValidName, isValidGeoRange } = require('../utils/validators');
+const referenceChecker = require('../utils/referenceChecker.js');
 
 const isValidLocation = (loc) => {
   return isValidName(loc?.name) && isValidGeoRange(loc?.geolocation);
@@ -34,9 +35,9 @@ const create = async (req, res) => {
       return res.status(400).json({ error: 'Invalid name: must be a non-empty string.' });
     }
 
-     if (!isValidGeoRange(loc?.geolocation)) {
-      return res.status(400).json({ 
-        error: 'Invalid geolocation: latitude must be between -90 and 90, longitude between -180 and 180.' 
+    if (!isValidGeoRange(loc?.geolocation)) {
+      return res.status(400).json({
+        error: 'Invalid geolocation: latitude must be between -90 and 90, longitude between -180 and 180.'
       });
     }
 
@@ -44,7 +45,7 @@ const create = async (req, res) => {
       name: loc.name,
       geolocation: loc.geolocation
     });
-    
+
     await newLocation.save();
     res.status(201).json({ message: 'Location successfully created.' });
   } catch (error) {
@@ -56,10 +57,10 @@ const create = async (req, res) => {
 };
 
 const update = async (req, res) => {
-  try { 
+  try {
     const { id } = req.params;
     const { name, geolocation } = req.body;
-    
+
     const existing = await Location.get({ id: id });
     if (!existing) {
       return res.status(404).json({ error: `Location with ID ${id} not found.` });
@@ -67,15 +68,15 @@ const update = async (req, res) => {
 
     const updateData = {};
 
-    if(name) {
-      if(!isValidName(name)){
+    if (name) {
+      if (!isValidName(name)) {
         return res.status(400).json({ error: 'Invalid name: must be a non-empty string.' });
       }
       updateData.name = name;
     }
 
-    if(geolocation){
-      if(!isValidGeoRange(geolocation)) {
+    if (geolocation) {
+      if (!isValidGeoRange(geolocation)) {
         return res.status(400).json({ error: 'Invalid geolocation: latitude must be between -90 and 90, longitude between -180 and 180.' });
       }
       updateData.geolocation = geolocation;
@@ -95,10 +96,29 @@ const update = async (req, res) => {
 const remove = async (req, res) => {
   try {
     const { id } = req.params;
-    
+    // If force is true, we bypass the referential integrity check.
+    // WARNING: Force deletion will leave orphaned references in Article records.
+    const force = req.query?.force === 'true';
+
     const existing = await Location.get({ id: id });
     if (!existing) {
       return res.status(404).json({ error: `Location with ID ${id} not found.` });
+    }
+
+    let references = 0;
+    if (!force) {
+      references = await referenceChecker.countReferences('location', id);
+      if (references > 0) {
+        return res.status(409).json({
+          error: `Cannot delete location because it is referenced by ${references} articles.`,
+          references: references
+        });
+      }
+    } else {
+      references = await referenceChecker.countReferences('location', id);
+      if (references > 0) {
+        console.warn(`[AUDIT] Location with ID "${id}" ("${existing.name}") was FORCE deleted. This left ${references} orphaned references in Articles.`);
+      }
     }
 
     await Location.delete({ id: id });

--- a/src/controllers/tagController.js
+++ b/src/controllers/tagController.js
@@ -1,4 +1,5 @@
 const Tag = require('../models/tag.js');
+const referenceChecker = require('../utils/referenceChecker.js');
 
 const isValidName = (name) => typeof name === 'string' && name.trim().length > 0;
 
@@ -18,7 +19,7 @@ const getAll = async (req, res) => {
 const getById = async (req, res) => {
   try {
     const id = req.params.id;
-    const tag = await Tag.get({ id: id});
+    const tag = await Tag.get({ id: id });
     if (!tag) {
       return res.status(404).json({ error: `Tag with ID ${id} not found.` });
     }
@@ -39,7 +40,7 @@ const create = async (req, res) => {
     const newTag = new Tag({
       name: tag.name
     });
-  
+
     await newTag.save();
     res.status(201).json({ message: 'Tag successfully created.' });
   } catch (error) {
@@ -51,7 +52,7 @@ const update = async (req, res) => {
   try {
     const id = req.params.id;
     const { name } = req.body;
-    
+
     const existing = await Tag.get({ id: id });
     if (!existing) {
       return res.status(404).json({ error: `Tag with ID ${id} not found.` });
@@ -59,7 +60,7 @@ const update = async (req, res) => {
 
     const updateData = {};
 
-    if(name){
+    if (name) {
       if (!isValidName(name)) {
         return res.status(400).json({ error: 'Invalid name format. Must be a non-empty string.' });
       }
@@ -70,7 +71,7 @@ const update = async (req, res) => {
       return res.status(400).json({ error: 'No valid fields provided for update.' });
     }
 
-    await Tag.update({ id: id}, updateData);
+    await Tag.update({ id: id }, updateData);
     res.status(200).json({ message: 'Tag successfully updated.' });
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -79,11 +80,30 @@ const update = async (req, res) => {
 
 const remove = async (req, res) => {
   try {
-  const id = req.params.id;
+    const id = req.params.id;
+    // If force is true, we bypass the referential integrity check.
+    // WARNING: Force deletion will leave orphaned references in Article records.
+    const force = req.query?.force === 'true';
 
     const existing = await Tag.get({ id: id });
     if (!existing) {
       return res.status(404).json({ error: `Tag with ID ${id} not found.` });
+    }
+
+    let references = 0;
+    if (!force) {
+      references = await referenceChecker.countReferences('tags', id);
+      if (references > 0) {
+        return res.status(409).json({
+          error: `Cannot delete tag because it is referenced by ${references} articles.`,
+          references: references
+        });
+      }
+    } else {
+      references = await referenceChecker.countReferences('tags', id);
+      if (references > 0) {
+        console.warn(`[AUDIT] Tag with ID "${id}" ("${existing.name}") was FORCE deleted. This left ${references} orphaned references in Articles.`);
+      }
     }
 
     await Tag.delete({ id: id });

--- a/src/routes/actorRoutes.js
+++ b/src/routes/actorRoutes.js
@@ -125,11 +125,19 @@ router.put('/:id', actorsController.update);
  *        description: Actor ID
  *        schema:
  *          type: string
+ *      - in: query
+ *        name: force
+ *        required: false
+ *        description: Force delete even if referenced by articles (leaves orphaned references)
+ *        schema:
+ *          type: boolean
  *    responses: 
  *      '200':
  *       description: Actor successfully deleted
  *      '404':
  *       description: Actor not found
+ *      '409':
+ *       description: Conflict - actor is referenced by articles
  *      '500': 
  *       description: Internal server error
  */

--- a/src/routes/locationRoutes.js
+++ b/src/routes/locationRoutes.js
@@ -126,11 +126,19 @@ router.put('/:id', locationsController.update);
  *         description: Location ID
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: force
+ *         required: false
+ *         description: Force delete even if referenced by articles (leaves orphaned references)
+ *         schema:
+ *           type: boolean
  *     responses:
  *       '200':
  *         description: Location successfully deleted
  *       '404':
  *         description: Location not found
+ *       '409':
+ *         description: Conflict - location is referenced by articles
  *       '500':
  *         description: Internal server error
  */

--- a/src/routes/tagRoutes.js
+++ b/src/routes/tagRoutes.js
@@ -112,11 +112,19 @@ router.put('/:id', tagsController.update);
  *         description: Tag ID
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: force
+ *         required: false
+ *         description: Force delete even if referenced by articles (leaves orphaned references)
+ *         schema:
+ *           type: boolean
  *     responses:
  *       '200':
  *         description: Tag successfully deleted
  *       '404':
  *         description: Tag not found
+ *       '409':
+ *         description: Conflict - tag is referenced by articles
  *       '500':
  *         description: Internal server error
  */

--- a/src/test/actor.test.js
+++ b/src/test/actor.test.js
@@ -3,6 +3,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const ActorController = require('../controllers/actorController');
 const Actor = require('../models/actor');
+const referenceChecker = require('../utils/referenceChecker.js');
 
 describe('Actor Controller - Unit Test', () => {
     let sandbox;
@@ -104,12 +105,40 @@ describe('Actor Controller - Unit Test', () => {
         expect(res.status.calledWith(400)).to.be.true;
     });
 
-    it('should delete actor', async () => {
+    it('should delete an actor when not referenced', async () => {
         req.params = { id: 'a1b2c3' };
+        req.query = {};
         sandbox.stub(Actor, 'get').resolves(fakeActor);
+        sandbox.stub(referenceChecker, 'countReferences').resolves(0);
         sandbox.stub(Actor, 'delete').resolves();
         await ActorController.remove(req, res);
         expect(res.status.calledWith(200)).to.be.true;
+    });
+
+    it('should not delete an actor and return 409 when referenced', async () => {
+        req.params = { id: 'a1b2c3' };
+        req.query = {};
+        sandbox.stub(Actor, 'get').resolves(fakeActor);
+        sandbox.stub(referenceChecker, 'countReferences').resolves(2);
+        const deleteStub = sandbox.stub(Actor, 'delete').resolves();
+        await ActorController.remove(req, res);
+        expect(res.status.calledWith(409)).to.be.true;
+        expect(res.json.calledWithMatch({
+            error: 'Cannot delete actor because it is referenced by 2 articles.',
+            references: 2
+        })).to.be.true;
+        expect(deleteStub.called).to.be.false;
+    });
+
+    it('should delete an actor and bypass check when force is true even if referenced', async () => {
+        req.params = { id: 'a1b2c3' };
+        req.query = { force: 'true' };
+        sandbox.stub(Actor, 'get').resolves(fakeActor);
+        const countStub = sandbox.stub(referenceChecker, 'countReferences');
+        sandbox.stub(Actor, 'delete').resolves();
+        await ActorController.remove(req, res);
+        expect(res.status.calledWith(200)).to.be.true;
+        expect(countStub.called).to.be.true;
     });
 
     it('should return 404 if actor not found on delete', async () => {
@@ -152,6 +181,7 @@ describe('Actor Controller - Unit Test', () => {
     it('should return 500 on database error in delete', async () => {
         req.params = { id: 'a1b2c3' };
         sandbox.stub(Actor, 'get').resolves(fakeActor);
+        sandbox.stub(referenceChecker, 'countReferences').resolves(0);
         sandbox.stub(Actor, 'delete').rejects(new Error('Database error'));
         await ActorController.remove(req, res);
         expect(res.status.calledWith(500)).to.be.true;

--- a/src/test/location.test.js
+++ b/src/test/location.test.js
@@ -3,6 +3,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const LocationController = require('../controllers/locationController');
 const Location = require('../models/location');
+const referenceChecker = require('../utils/referenceChecker.js');
 
 describe('Location Controller Unit Test', () => {
   let sandbox;
@@ -75,13 +76,42 @@ describe('Location Controller Unit Test', () => {
     expect(res.status.calledWith(404)).to.be.true;
   });
 
-  it('should delete a location', async () => {
+  it('should delete a location when not referenced', async () => {
     req.params = { id: 'abc123' };
+    req.query = {};
     sandbox.stub(Location, 'get').resolves(fakeLocation);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(0);
     sandbox.stub(Location, 'delete').resolves();
     await LocationController.remove(req, res);
     expect(res.status.calledWith(200)).to.be.true;
     expect(res.json.calledWithMatch({ message: 'Location successfully deleted.' })).to.be.true;
+  });
+
+  it('should not delete a location and return 409 when referenced', async () => {
+    req.params = { id: 'abc123' };
+    req.query = {};
+    sandbox.stub(Location, 'get').resolves(fakeLocation);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(3);
+    const deleteStub = sandbox.stub(Location, 'delete').resolves();
+    await LocationController.remove(req, res);
+    expect(res.status.calledWith(409)).to.be.true;
+    expect(res.json.calledWithMatch({
+      error: 'Cannot delete location because it is referenced by 3 articles.',
+      references: 3
+    })).to.be.true;
+    expect(deleteStub.called).to.be.false;
+  });
+
+  it('should delete a location and bypass check when force is true even if referenced', async () => {
+    req.params = { id: 'abc123' };
+    req.query = { force: 'true' };
+    sandbox.stub(Location, 'get').resolves(fakeLocation);
+    const countStub = sandbox.stub(referenceChecker, 'countReferences');
+    sandbox.stub(Location, 'delete').resolves();
+    await LocationController.remove(req, res);
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.calledWithMatch({ message: 'Location successfully deleted.' })).to.be.true;
+    expect(countStub.called).to.be.true;
   });
 
   it('should return 404 on delete if not found', async () => {
@@ -124,6 +154,7 @@ describe('Location Controller Unit Test', () => {
   it('should return 500 on database error in delete', async () => {
     req.params = { id: 'abc123' };
     sandbox.stub(Location, 'get').resolves(fakeLocation);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(0);
     sandbox.stub(Location, 'delete').rejects(new Error('Database error'));
     await LocationController.remove(req, res);
     expect(res.status.calledWith(500)).to.be.true;

--- a/src/test/routes.integration.test.js
+++ b/src/test/routes.integration.test.js
@@ -87,12 +87,48 @@ describe('Routes Integration Tests', () => {
   });
 
   describe('DELETE /actors/:id', () => {
-    it('should delete an actor', async () => {
+    it('should delete an actor when not referenced', async () => {
       sandbox.stub(Actor, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([])
+      });
       sandbox.stub(Actor, 'delete').resolves();
 
       const res = await request(app).delete('/actors/1');
       expect(res.status).to.equal(200);
+    });
+
+    it('should return 409 when actor is referenced', async () => {
+      sandbox.stub(Actor, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', actorsMentioned: [{ S: '1' }] },
+          { id: 'art2', actorsMentioned: [{ S: '1' }] }
+        ])
+      });
+      const deleteStub = sandbox.stub(Actor, 'delete').resolves();
+
+      const res = await request(app).delete('/actors/1');
+      expect(res.status).to.equal(409);
+      expect(res.body).to.deep.equal({
+        error: 'Cannot delete actor because it is referenced by 2 articles.',
+        references: 2
+      });
+      expect(deleteStub.called).to.be.false;
+    });
+
+    it('should delete actor when forced even if referenced', async () => {
+      sandbox.stub(Actor, 'get').resolves({ id: '1', name: 'Test' });
+      const scanStub = sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', actorsMentioned: [{ S: '1' }] }
+        ])
+      });
+      sandbox.stub(Actor, 'delete').resolves();
+
+      const res = await request(app).delete('/actors/1?force=true');
+      expect(res.status).to.equal(200);
+      expect(scanStub.called).to.be.true;
     });
   });
 
@@ -202,6 +238,51 @@ describe('Routes Integration Tests', () => {
     });
   });
 
+  describe('DELETE /locations/:id', () => {
+    it('should delete a location when not referenced', async () => {
+      sandbox.stub(Location, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([])
+      });
+      sandbox.stub(Location, 'delete').resolves();
+
+      const res = await request(app).delete('/locations/1');
+      expect(res.status).to.equal(200);
+    });
+
+    it('should return 409 when location is referenced', async () => {
+      sandbox.stub(Location, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', location: [{ S: '1' }] }
+        ])
+      });
+      const deleteStub = sandbox.stub(Location, 'delete').resolves();
+
+      const res = await request(app).delete('/locations/1');
+      expect(res.status).to.equal(409);
+      expect(res.body).to.deep.equal({
+        error: 'Cannot delete location because it is referenced by 1 articles.',
+        references: 1
+      });
+      expect(deleteStub.called).to.be.false;
+    });
+
+    it('should delete location when forced even if referenced', async () => {
+      sandbox.stub(Location, 'get').resolves({ id: '1', name: 'Test' });
+      const scanStub = sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', location: [{ S: '1' }] }
+        ])
+      });
+      sandbox.stub(Location, 'delete').resolves();
+
+      const res = await request(app).delete('/locations/1?force=true');
+      expect(res.status).to.equal(200);
+      expect(scanStub.called).to.be.true;
+    });
+  });
+
   // Tag Routes
   describe('GET /tags', () => {
     it('should return all tags', async () => {
@@ -248,12 +329,49 @@ describe('Routes Integration Tests', () => {
   });
 
   describe('DELETE /tags/:id', () => {
-    it('should delete a tag', async () => {
+    it('should delete a tag when not referenced', async () => {
       sandbox.stub(Tag, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([])
+      });
       sandbox.stub(Tag, 'delete').resolves();
 
       const res = await request(app).delete('/tags/1');
       expect(res.status).to.equal(200);
+    });
+
+    it('should return 409 when tag is referenced', async () => {
+      sandbox.stub(Tag, 'get').resolves({ id: '1', name: 'Test' });
+      sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', tags: [{ S: '1' }] },
+          { id: 'art2', tags: [{ S: '1' }] },
+          { id: 'art3', tags: [{ S: '1' }] }
+        ])
+      });
+      const deleteStub = sandbox.stub(Tag, 'delete').resolves();
+
+      const res = await request(app).delete('/tags/1');
+      expect(res.status).to.equal(409);
+      expect(res.body).to.deep.equal({
+        error: 'Cannot delete tag because it is referenced by 3 articles.',
+        references: 3
+      });
+      expect(deleteStub.called).to.be.false;
+    });
+
+    it('should delete tag when forced even if referenced', async () => {
+      sandbox.stub(Tag, 'get').resolves({ id: '1', name: 'Test' });
+      const scanStub = sandbox.stub(Article, 'scan').returns({
+        exec: sandbox.stub().resolves([
+          { id: 'art1', tags: [{ S: '1' }] }
+        ])
+      });
+      sandbox.stub(Tag, 'delete').resolves();
+
+      const res = await request(app).delete('/tags/1?force=true');
+      expect(res.status).to.equal(200);
+      expect(scanStub.called).to.be.true;
     });
   });
 });

--- a/src/test/tag.test.js
+++ b/src/test/tag.test.js
@@ -3,6 +3,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const TagController = require('../controllers/tagController.js');
 const Tag = require('../models/tag.js');
+const referenceChecker = require('../utils/referenceChecker.js');
 
 describe('Tag Controller Unit Test', function() {
   let sandbox;
@@ -56,13 +57,42 @@ describe('Tag Controller Unit Test', function() {
     expect(res.json.calledWithMatch({ message: 'Tag successfully updated.' })).to.be.true;
   });
 
-  it('should delete a tag', async function() {
+  it('should delete a tag when not referenced', async function() {
     req.params = { id: '123' };
+    req.query = {};
     sandbox.stub(Tag, 'get').resolves(fakeTag);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(0);
     sandbox.stub(Tag, 'delete').resolves();
     await TagController.remove(req, res);
     expect(res.status.calledWith(200)).to.be.true;
     expect(res.json.calledWithMatch({ message: 'Tag successfully deleted.' })).to.be.true;
+  });
+
+  it('should not delete a tag and return 409 when referenced', async function() {
+    req.params = { id: '123' };
+    req.query = {};
+    sandbox.stub(Tag, 'get').resolves(fakeTag);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(5);
+    const deleteStub = sandbox.stub(Tag, 'delete').resolves();
+    await TagController.remove(req, res);
+    expect(res.status.calledWith(409)).to.be.true;
+    expect(res.json.calledWithMatch({
+      error: 'Cannot delete tag because it is referenced by 5 articles.',
+      references: 5
+    })).to.be.true;
+    expect(deleteStub.called).to.be.false;
+  });
+
+  it('should delete a tag and bypass check when force is true even if referenced', async function() {
+    req.params = { id: '123' };
+    req.query = { force: 'true' };
+    sandbox.stub(Tag, 'get').resolves(fakeTag);
+    const countStub = sandbox.stub(referenceChecker, 'countReferences');
+    sandbox.stub(Tag, 'delete').resolves();
+    await TagController.remove(req, res);
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.calledWithMatch({ message: 'Tag successfully deleted.' })).to.be.true;
+    expect(countStub.called).to.be.true;
   });
 
   // Priority 2: Missing 404 tests
@@ -158,6 +188,7 @@ describe('Tag Controller Unit Test', function() {
   it('should return 500 on database error in delete', async function() {
     req.params = { id: '123' };
     sandbox.stub(Tag, 'get').resolves(fakeTag);
+    sandbox.stub(referenceChecker, 'countReferences').resolves(0);
     sandbox.stub(Tag, 'delete').rejects(new Error('Database error'));
     await TagController.remove(req, res);
     expect(res.status.calledWith(500)).to.be.true;

--- a/src/utils/referenceChecker.js
+++ b/src/utils/referenceChecker.js
@@ -1,0 +1,25 @@
+const Article = require('../models/article.js');
+
+// Counts the number of active articles referencing a given entity.
+const countReferences = async (fieldName, id) => {
+  const articles = await Article.scan().exec();
+  const referencingArticles = articles.filter(article => {
+    const list = article[fieldName];
+    if (!Array.isArray(list)) {
+      return false;
+    }
+    return list.some(item => {
+      if (item && typeof item === 'object' && typeof item.S === 'string') {
+        return item.S === id;
+      }
+      return false;
+    });
+  });
+  return referencingArticles.length;
+};
+
+
+module.exports = {
+  countReferences
+};
+


### PR DESCRIPTION
### Descripción
Se implementó un sistema de protección de integridad referencial en el backend para evitar la eliminación de etiquetas (Tags), ubicaciones (Locations) y actores (Actors) que sigan siendo referenciados por artículos (Articles) activos. Esto previene la creación de referencias huérfanas en la base de datos de DynamoDB.

### Cambios Realizados

1. **Nuevo Utility Helper (`src/utils/referenceChecker.js`):**
   * Se creó la función `countReferences(fieldName, id)` que escanea la tabla de `Articles` buscando referencias en memoria.
   * Soporta tanto el formato estructurado con el que DynamoDB/Dynamoose serializa las listas de objetos (ej. `[{ S: "id" }]`).

2. **Controladores Actualizados (`tagController.js`, `locationController.js`, `actorController.js`):**
   * Se modificó el método `remove` para verificar si existen artículos referenciando a la entidad antes de proceder con el borrado.
   * Si existen referencias y no se especifica el parámetro `force`, el backend responde con un código **HTTP 409 Conflict** y un JSON con el mensaje de error y el conteo exacto de artículos dependientes.
   * Se respeta el código **HTTP 404** si la entidad no existe.
   * Se añadió soporte para omitir la validación de integridad usando el parámetro opcional de consulta `?force=true` (forzar eliminación), documentando los riesgos de dejar referencias huérfanas en los comentarios del código.

3. **Documentación de Rutas Actualizada (`tagRoutes.js`, `locationRoutes.js`, `actorRoutes.js`):**
   * Se actualizó la documentación de Swagger JSDoc para incluir el parámetro de consulta `force` (`?force=true`) en las rutas DELETE correspondientes.

4. **Pruebas Unitarias e Integración Añadidas & Actualizadas:**
   * Se añadieron pruebas unitarias en `tag.test.js`, `location.test.js` y `actor.test.js` stubbeando el checker de referencias.
   * Se actualizaron y expandieron las pruebas de integración en `routes.integration.test.js` para simular y validar todos los flujos (eliminación segura, bloqueo 409 Conflict con conteo exacto, eliminación forzada y casos no encontrados 404) usando stubs aislados y deterministas que no modifican la base de datos real.

### Criterios de Aceptación Cumplidos
- La eliminación de una entidad sin referencias funciona correctamente (Retorna HTTP 200).
- La eliminación de una entidad referenciada por uno o más artículos es bloqueada (Retorna HTTP 409 Conflict).
- El mensaje de error de conflicto incluye el número exacto de referencias activas.
- El parámetro `?force=true` permite omitir la validación de integridad referencial.
- Las pruebas unitarias y de integración pasan correctamente (109 tests aprobados).
