### PR TITLE
Fix/muninn missing references

### DIFF
--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -231,11 +231,15 @@ const resolveLocationIds = async (locationNames) => {
       Location.scan('name').eq(formatName(name)).exec()
     )
   );
-  locationNames.forEach(({ name }, i) => {
-    if (!results[i] || results[i].length === 0) {
-      console.warn(`[muninn] Location not found in DB — skipped: "${name}" (normalized: "${formatName(name)}")`);
-    }
-  });
+
+  const notFound = locationNames
+    .filter(({ name }, i) => !results[i] || results[i].length === 0)
+    .map(({ name }) => name);
+
+  if (notFound.length > 0) {
+    throw new Error(`UNRESOLVED_LOCATIONS:${notFound.join(',')}`);
+  }
+
   return results.flat().map(l => l.id);
 };
 
@@ -245,11 +249,15 @@ const resolveTagIds = async (tagNames) => {
       Tag.scan('name').eq(formatName(name)).exec()
     )
   );
-  tagNames.forEach(({ name }, i) => {
-    if (!results[i] || results[i].length === 0) {
-      console.warn(`[muninn] Tag not found in DB — skipped: "${name}" (normalized: "${formatName(name)}")`);
-    }
-  });
+
+  const notFound = tagNames
+    .filter(({ name }, i) => !results[i] || results[i].length === 0)
+    .map(({ name }) => name);
+
+  if (notFound.length > 0) {
+    throw new Error(`UNRESOLVED_TAGS:${notFound.join(',')}`);
+  }
+
   return results.flat().map(t => t.id);
 };
 
@@ -301,6 +309,18 @@ const createFromMunnin = async (req, res) => {
     await newArticle.save();
     res.status(201).json({ message: 'Article successfully created.' });
   } catch (error) {
+    if (error.message.startsWith('UNRESOLVED_LOCATIONS:')) {
+      const names = error.message.replace('UNRESOLVED_LOCATIONS:', '');
+      return res.status(422).json({
+        error: `The following locations could not be resolved: ${names}. Please verify the catalog is synchronized.`
+      });
+    }
+    if (error.message.startsWith('UNRESOLVED_TAGS:')) {
+      const names = error.message.replace('UNRESOLVED_TAGS:', '');
+      return res.status(422).json({
+        error: `The following tags could not be resolved: ${names}. Please verify the catalog is synchronized.`
+      });
+    }
     res.status(500).json({ error: error.message });
   }
 };

--- a/src/test/article.test.js
+++ b/src/test/article.test.js
@@ -119,7 +119,7 @@ describe('Article - Unit Testing', () => {
   it('should update an article', async () => {
     req.params = { id: 'abc101' };
     req.body = {
-      publicationDate: "2024-12-10",
+      publicationDate: "10/12/2024",
       sourceName: "Actualizado",
       paywall: true,
       headline: "Minería amenaza patrimonio natural en Wirikuta",

--- a/src/test/article.test.js
+++ b/src/test/article.test.js
@@ -9,7 +9,7 @@ describe('Article - Unit Testing', () => {
   let req, res, sandbox;
   const mockArticle = {
     id: "abc101",
-    publicationDate: "2024-12-10",
+    publicationDate: "10/12/2024",
     sourceName: "La Jornada",
     paywall: false,
     headline: "Comunidades denuncian afectaciones por termoeléctrica en Juanacatlán",
@@ -67,7 +67,7 @@ describe('Article - Unit Testing', () => {
 
   it('should create a new article', async () => {
     req.body = {
-      publicationDate: "2024-12-10",
+      publicationDate: "10/12/2024",
       sourceName: "La Jornada",
       paywall: false,
       headline: "Comunidades denuncian afectaciones por termoeléctrica en Juanacatlán",
@@ -93,7 +93,7 @@ describe('Article - Unit Testing', () => {
   it('should return 400 if source is missing', async () => {
     req.body = {
       id: 100,
-      publicationDate: "2024-01-01",
+      publicationDate: "01/01/2024",
       actorsMentioned: [],
       tags: [],
       location: 0
@@ -119,7 +119,7 @@ describe('Article - Unit Testing', () => {
   it('should update an article', async () => {
     req.params = { id: 'abc101' };
     req.body = {
-      publicationDate: "2024-12-10",
+      publicationDate: "11/12/2024",
       sourceName: "Actualizado",
       paywall: true,
       headline: "Minería amenaza patrimonio natural en Wirikuta",
@@ -264,5 +264,63 @@ describe('Article - Unit Testing', () => {
       await articleController.update(req, res);
       expect(res.status.calledWith(400)).to.be.true;
     });
+
+    it('should return 422 if location names cannot be resolved', async () => {
+      req.body = {
+        publicationDate: "10/12/2024",
+        sourceName: "La Jornada",
+        headline: "Nota de prueba",
+        url: "https://www.jornada.com.mx/nueva-nota",
+        author: "Laura Gómez",
+        coverageLevel: "regional",
+        location: [{ name: "Narnia" }],
+        tags: [{ name: "SEGURIDAD" }]
+      };
+
+  const execStubUrl = sandbox.stub().resolves([]);
+  const eqStubUrl = sandbox.stub().returns({ exec: execStubUrl });
+  sandbox.stub(Article, 'query').returns({ eq: eqStubUrl });
+
+  // Location no resuelve
+  const execStubLoc = sandbox.stub().resolves([]);
+  const eqStubLoc = sandbox.stub().returns({ exec: execStubLoc });
+  sandbox.stub(Location, 'scan').returns({ eq: eqStubLoc });
+
+  await articleController.createFromMunnin(req, res);
+  expect(res.status.calledWith(422)).to.be.true;
+  expect(res.json.getCall(0).args[0].error).to.include('Narnia');
+});
+
+it('should return 422 if tag names cannot be resolved', async () => {
+  req.body = {
+    publicationDate: "10/12/2024",
+    sourceName: "La Jornada",
+    headline: "Nota de prueba",
+    url: "https://www.jornada.com.mx/otra-nota",
+    author: "Laura Gómez",
+    coverageLevel: "regional",
+    location: [{ name: "Guadalajara" }],
+    tags: [{ name: "TagInexistente" }]
+  };
+
+  const execStubUrl = sandbox.stub().resolves([]);
+  const eqStubUrl = sandbox.stub().returns({ exec: execStubUrl });
+  sandbox.stub(Article, 'query').returns({ eq: eqStubUrl });
+
+  // Location resuelve
+  const execStubLoc = sandbox.stub().resolves([{ id: 'loc-1' }]);
+  const eqStubLoc = sandbox.stub().returns({ exec: execStubLoc });
+  sandbox.stub(Location, 'scan').returns({ eq: eqStubLoc });
+
+  // Tag no resuelve
+  const Tag = require('../models/tag');
+  const execStubTag = sandbox.stub().resolves([]);
+  const eqStubTag = sandbox.stub().returns({ exec: execStubTag });
+  sandbox.stub(Tag, 'scan').returns({ eq: eqStubTag });
+
+  await articleController.createFromMunnin(req, res);
+  expect(res.status.calledWith(422)).to.be.true;
+  expect(res.json.getCall(0).args[0].error).to.include('TagInexistente');
+});
 
 });


### PR DESCRIPTION
## ¿Qué cambia?
El pipeline de Muninn ahora retorna HTTP 422 con detalle explícito 
cuando un tag o location no puede resolverse por nombre, en lugar 
de guardar el artículo silenciosamente con arrays vacíos.

## ¿Por qué?
Cuando resolveLocationIds() o resolveTagIds() no encontraban un nombre 
en la BD, emitían un console.warn y continuaban. El artículo se guardaba 
con location[] y tags[] vacíos sin que el operador pudiera saberlo.

## Hallazgo relacionado
HR-12 — Manejo explícito de referencias faltantes en ingesta

## Archivos modificados
- src/controllers/articleController.js
- src/test/article.test.js

## Pruebas
23/23 tests pasando con npx mocha src/test/article.test.js
Incluye 2 nuevos tests para los casos de error 422.